### PR TITLE
Feature/qna board : qna 게시판 구현

### DIFF
--- a/back-end/src/main/java/com/kosa/springcoffee/controller/BoardController.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/controller/BoardController.java
@@ -25,14 +25,14 @@ public class BoardController {
 
     @PostMapping("/register")
     public ResponseEntity<Long> create(@RequestBody BoardDTO dto) {
-        boardService.create(dto);
-        log.info("게시글 등록");
         Long num = boardService.create(dto);
+        log.info("게시글 등록");
         return new ResponseEntity<>(num, HttpStatus.OK);
     }
+
     @GetMapping(value = "/{boardNo}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<BoardDTO> read(@PathVariable("boardNo") Long boardNo){
-        log.info(boardNo+"상세 페이지");
+        log.info(boardNo+" 상세 페이지");
         return new ResponseEntity<>(boardService.get(boardNo), HttpStatus.OK);
     }
 

--- a/back-end/src/main/java/com/kosa/springcoffee/controller/QnaBoardController.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/controller/QnaBoardController.java
@@ -1,0 +1,76 @@
+package com.kosa.springcoffee.controller;
+
+import com.kosa.springcoffee.dto.*;
+import com.kosa.springcoffee.entity.QnaBoard;
+import com.kosa.springcoffee.service.QnaBoardService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v3")
+@Log4j2
+@RequiredArgsConstructor
+public class QnaBoardController {
+
+    private final QnaBoardService qnaBoardService;
+
+    @PostMapping("/register")
+    public ResponseEntity<Long> create(@RequestBody QnaBoardDTO dto) {
+        qnaBoardService.create(dto);
+        log.info("게시글 등록");
+        Long num = qnaBoardService.create(dto);
+        return new ResponseEntity<>(num, HttpStatus.OK);
+    }
+
+    @GetMapping(value = "/list", produces = MediaType.APPLICATION_JSON_VALUE)
+    public PageResultDTO<QnaBoardDTO, QnaBoard> readAll(PageRequestDTO pageRequestDTO) {
+        log.info("Q&A 전체 조회");
+        return qnaBoardService.readAll(pageRequestDTO);
+    }
+
+    @GetMapping(value = "/{qnaBoardNo}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<QnaBoardDTO> read(@PathVariable("qnaBoardNo") Long qnaBoardNo){
+        log.info(qnaBoardNo+" 상세 페이지");
+        return new ResponseEntity<>(qnaBoardService.get(qnaBoardNo), HttpStatus.OK);
+    }
+
+    @GetMapping(value = "/list/{category}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public PageResultDTO<QnaBoardDTO, QnaBoard> getCategory(CategoryPageRequestDTO pageRequestDTO, @PathVariable String category) {
+        log.info("Q&A " + category + "조회");
+        return qnaBoardService.getCategory(pageRequestDTO);
+    }
+
+    @GetMapping(value = "/list/answer/{isAnswered}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public PageResultDTO<QnaBoardDTO, QnaBoard> getAnswered(AnsweredPageRequestDTO pageRequestDTO, @PathVariable Boolean isAnswered) {
+        log.info("Q&A " + isAnswered + "조회");
+        System.out.println("isAnswer : "+isAnswered);
+        System.out.println(pageRequestDTO);
+        return qnaBoardService.getAnswered(pageRequestDTO);
+    }
+
+    @GetMapping(value = "/all", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<QnaBoardDTO>> getList(String email){
+        log.info(email);
+        return new ResponseEntity<>(qnaBoardService.getAllWithWriter(email), HttpStatus.OK);
+    }
+
+    @PutMapping(value = "/{qnaBoardNo}", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> modify(@RequestBody QnaBoardDTO qnaBoardDTO){
+        log.info(qnaBoardDTO);
+        qnaBoardService.modify(qnaBoardDTO);
+        return new ResponseEntity<>("modified", HttpStatus.OK);
+    }
+
+    @DeleteMapping(value = "/{qnaBoardNo}", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> remove(@PathVariable("qnaBoardNo") Long qnaBoardNo){
+        log.info(qnaBoardNo);
+        qnaBoardService.remove(qnaBoardNo);
+        return new ResponseEntity<>("removed", HttpStatus.OK);
+    }
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/controller/QnaBoardController.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/controller/QnaBoardController.java
@@ -59,9 +59,21 @@ public class QnaBoardController {
     }
 
     @GetMapping(value = "/all", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<QnaBoardDTO>> getList(String email){
-        log.info(email);
+    public ResponseEntity<List<QnaBoardDTO>> getList(@RequestParam(value = "email") String email){
+        log.info(email + " 검색");
         return new ResponseEntity<>(qnaBoardService.getAllWithWriter(email), HttpStatus.OK);
+    }
+
+    @GetMapping(value = "/search/keyword")
+    public PageResultDTO<QnaBoardDTO, QnaBoard> searchKeyword(KeywordPageRequestDTO requestDTO) {
+        log.info(requestDTO.getKeyword() + " 검색");
+        return qnaBoardService.searchKeyword(requestDTO);
+    }
+
+    @GetMapping(value = "/search/email")
+    public PageResultDTO<QnaBoardDTO, QnaBoard> searchEmail(EmailPageRequestDTO requestDTO) {
+        log.info(requestDTO.getEmail() + " 검색");
+        return qnaBoardService.searchEmail(requestDTO);
     }
 
     @PutMapping(value = "/{qnaBoardNo}", produces = MediaType.TEXT_PLAIN_VALUE)

--- a/back-end/src/main/java/com/kosa/springcoffee/controller/QnaBoardController.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/controller/QnaBoardController.java
@@ -22,9 +22,8 @@ public class QnaBoardController {
 
     @PostMapping("/register")
     public ResponseEntity<Long> create(@RequestBody QnaBoardDTO dto) {
-        qnaBoardService.create(dto);
-        log.info("게시글 등록");
         Long num = qnaBoardService.create(dto);
+        log.info("게시글 등록");
         return new ResponseEntity<>(num, HttpStatus.OK);
     }
 

--- a/back-end/src/main/java/com/kosa/springcoffee/controller/QnaBoardController.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/controller/QnaBoardController.java
@@ -46,12 +46,17 @@ public class QnaBoardController {
         return qnaBoardService.getCategory(pageRequestDTO);
     }
 
-    @GetMapping(value = "/list/answer/{isAnswered}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/list/all/{isAnswered}", produces = MediaType.APPLICATION_JSON_VALUE)
     public PageResultDTO<QnaBoardDTO, QnaBoard> getAnswered(AnsweredPageRequestDTO pageRequestDTO, @PathVariable Boolean isAnswered) {
         log.info("Q&A " + isAnswered + "조회");
-        System.out.println("isAnswer : "+isAnswered);
-        System.out.println(pageRequestDTO);
         return qnaBoardService.getAnswered(pageRequestDTO);
+    }
+
+    @GetMapping(value = "/list/{category}/{isAnswered}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public PageResultDTO<QnaBoardDTO, QnaBoard> getCategoryAndAnswered(QnaCategoryAnsweredPageRequestDTO pageRequestDTO, @PathVariable String category, @PathVariable Boolean isAnswered) {
+        log.info("Q&A " + category + ", " + isAnswered + " 조회");
+        System.out.println(pageRequestDTO);
+        return qnaBoardService.getCategoryAndAnswered(pageRequestDTO);
     }
 
     @GetMapping(value = "/all", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/back-end/src/main/java/com/kosa/springcoffee/controller/QnaReplyController.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/controller/QnaReplyController.java
@@ -25,10 +25,10 @@ public class QnaReplyController {
         return new ResponseEntity<>(num, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/{qnaBoardNo}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<QnaReplyDTO> read(@PathVariable("qnaBoardNo") Long qnaBoardNo) {
-        log.info(qnaBoardNo + " 답변 조회");
-        return new ResponseEntity<>(qnaReplyService.get(qnaBoardNo), HttpStatus.OK);
+    @GetMapping(value = "/{qnaReplyNo}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<QnaReplyDTO> read(@PathVariable("qnaReplyNo") Long qnaReplyNo) {
+        log.info(qnaReplyNo + " 답변 조회");
+        return new ResponseEntity<>(qnaReplyService.get(qnaReplyNo), HttpStatus.OK);
     }
 
     @PutMapping(value = "/{qnaReplyNo}", produces = MediaType.TEXT_PLAIN_VALUE)

--- a/back-end/src/main/java/com/kosa/springcoffee/controller/QnaReplyController.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/controller/QnaReplyController.java
@@ -1,0 +1,48 @@
+package com.kosa.springcoffee.controller;
+
+import com.kosa.springcoffee.dto.QnaReplyDTO;
+import com.kosa.springcoffee.service.QnaReplyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v4")
+@Log4j2
+@RequiredArgsConstructor
+public class QnaReplyController {
+
+    private final QnaReplyService qnaReplyService;
+
+    @PostMapping("/register")
+    public ResponseEntity<Long> create(@RequestBody QnaReplyDTO dto) {
+        log.info(dto.getQnaBoardNo() + " 답변 등록");
+        System.out.println(dto);
+        Long num = qnaReplyService.create(dto);
+        return new ResponseEntity<>(num, HttpStatus.OK);
+    }
+
+    @GetMapping(value = "/{qnaBoardNo}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<QnaReplyDTO> read(@PathVariable("qnaBoardNo") Long qnaBoardNo) {
+        log.info(qnaBoardNo + " 답변 조회");
+        return new ResponseEntity<>(qnaReplyService.get(qnaBoardNo), HttpStatus.OK);
+    }
+
+    @PutMapping(value = "/{qnaReplyNo}", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> modify(@RequestBody QnaReplyDTO qnaReplyDTO){
+        log.info(qnaReplyDTO + " 수정");
+        qnaReplyService.modify(qnaReplyDTO);
+        return new ResponseEntity<>("modified", HttpStatus.OK);
+    }
+
+    @DeleteMapping(value = "/{qnaReplyNo}", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> remove(@PathVariable("qnaReplyNo") Long qnaReplyNo) {
+        log.info(qnaReplyNo + " 삭제");
+        qnaReplyService.remove(qnaReplyNo);
+        return new ResponseEntity<>("removed", HttpStatus.OK);
+    }
+
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/dto/AnsweredPageRequestDTO.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/dto/AnsweredPageRequestDTO.java
@@ -1,0 +1,29 @@
+package com.kosa.springcoffee.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Builder
+@AllArgsConstructor
+@Data
+public class AnsweredPageRequestDTO {
+
+    private int page;
+    private int size;
+//    private String category;
+    private Boolean isAnswered;
+
+    public AnsweredPageRequestDTO() {
+        this.page = 1;
+        this.size = 10;
+    }
+
+    public Pageable getPageable(Sort sort) {
+        return PageRequest.of(page-1, size, sort);
+    }
+
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/dto/EmailPageRequestDTO.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/dto/EmailPageRequestDTO.java
@@ -1,0 +1,26 @@
+package com.kosa.springcoffee.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Builder
+@AllArgsConstructor
+@Data
+public class EmailPageRequestDTO {
+    private int page;
+    private int size;
+    private String email;
+
+    public EmailPageRequestDTO() {
+        this.page = 1;
+        this.size = 10;
+    }
+
+    public Pageable getPageable(Sort sort) {
+        return PageRequest.of(page-1, size, sort);
+    }
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/dto/KeywordPageRequestDTO.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/dto/KeywordPageRequestDTO.java
@@ -1,0 +1,27 @@
+package com.kosa.springcoffee.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Builder
+@AllArgsConstructor
+@Data
+public class KeywordPageRequestDTO {
+
+    private int page;
+    private int size;
+    private String keyword;
+
+    public KeywordPageRequestDTO() {
+        this.page = 1;
+        this.size = 10;
+    }
+
+    public Pageable getPageable(Sort sort) {
+        return PageRequest.of(page-1, size, sort);
+    }
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/dto/QnaBoardDTO.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/dto/QnaBoardDTO.java
@@ -16,5 +16,6 @@ public class QnaBoardDTO {
     private String content;
     private String regDate, modDate;
     private String writer;
-
+    private String category;
+    private Boolean isAnswered;
 }

--- a/back-end/src/main/java/com/kosa/springcoffee/dto/QnaBoardDTO.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/dto/QnaBoardDTO.java
@@ -1,0 +1,20 @@
+package com.kosa.springcoffee.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class QnaBoardDTO {
+
+    private Long qnaBoardNo;
+    private String title;
+    private String content;
+    private String regDate, modDate;
+    private String writer;
+
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/dto/QnaBoardDTO.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/dto/QnaBoardDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -17,5 +19,6 @@ public class QnaBoardDTO {
     private String regDate, modDate;
     private String writer;
     private String category;
+    private List<QnaReplyDTO> replyList;
     private Boolean isAnswered;
 }

--- a/back-end/src/main/java/com/kosa/springcoffee/dto/QnaCategoryAnsweredPageRequestDTO.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/dto/QnaCategoryAnsweredPageRequestDTO.java
@@ -10,13 +10,14 @@ import org.springframework.data.domain.Sort;
 @Builder
 @AllArgsConstructor
 @Data
-public class AnsweredPageRequestDTO {
+public class QnaCategoryAnsweredPageRequestDTO {
 
     private int page;
     private int size;
+    private String category;
     private Boolean isAnswered;
 
-    public AnsweredPageRequestDTO() {
+    public QnaCategoryAnsweredPageRequestDTO() {
         this.page = 1;
         this.size = 10;
     }

--- a/back-end/src/main/java/com/kosa/springcoffee/dto/QnaReplyDTO.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/dto/QnaReplyDTO.java
@@ -1,0 +1,19 @@
+package com.kosa.springcoffee.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class QnaReplyDTO {
+
+    private Long qnaReplyNo;
+    private String content;
+    private String replyer;
+    private Long qnaBoardNo;
+
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/entity/Board.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/entity/Board.java
@@ -4,7 +4,7 @@ import lombok.*;
 
 import javax.persistence.*;
 
-@Entity(name = "sc_board")
+@Entity(name = "sc_notice_board")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/back-end/src/main/java/com/kosa/springcoffee/entity/QnaBoard.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/entity/QnaBoard.java
@@ -3,6 +3,8 @@ package com.kosa.springcoffee.entity;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity(name = "sc_qna_board")
 @Getter
@@ -29,6 +31,9 @@ public class QnaBoard extends BaseEntity {
 
     @Column(nullable = false)
     private Boolean isAnswered;
+
+    @OneToMany(mappedBy = "qnaBoard", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, fetch = FetchType.EAGER)
+    List<QnaReply> qnaReplies = new ArrayList<>();
 
     @Builder
     public QnaBoard(Long qnaBoardNo, String title, String content, Member writer, String category) {

--- a/back-end/src/main/java/com/kosa/springcoffee/entity/QnaBoard.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/entity/QnaBoard.java
@@ -25,6 +25,12 @@ public class QnaBoard extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member writer;
 
+    @Column(length = 50, nullable = false)
+    private String category;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean isAnswered;
+
     public void changeTitle(String title) {
         this.title = title;
     }

--- a/back-end/src/main/java/com/kosa/springcoffee/entity/QnaBoard.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/entity/QnaBoard.java
@@ -6,7 +6,6 @@ import javax.persistence.*;
 
 @Entity(name = "sc_qna_board")
 @Getter
-//@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString

--- a/back-end/src/main/java/com/kosa/springcoffee/entity/QnaBoard.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/entity/QnaBoard.java
@@ -6,7 +6,7 @@ import javax.persistence.*;
 
 @Entity(name = "sc_qna_board")
 @Getter
-@Builder
+//@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
@@ -28,8 +28,19 @@ public class QnaBoard extends BaseEntity {
     @Column(length = 50, nullable = false)
     private String category;
 
-    @Column(columnDefinition = "boolean default false")
+    @Column(nullable = false)
     private Boolean isAnswered;
+
+    @Builder
+    public QnaBoard(Long qnaBoardNo, String title, String content, Member writer, String category) {
+        this.isAnswered = false; // default
+
+        this.qnaBoardNo = qnaBoardNo;
+        this.title = title;
+        this.content = content;
+        this.writer = writer;
+        this.category = category;
+    }
 
     public void changeTitle(String title) {
         this.title = title;
@@ -38,5 +49,8 @@ public class QnaBoard extends BaseEntity {
     public void changeContent(String content) {
         this.content = content;
     }
-}
 
+    public void changeIsAnswered(Boolean isAnswered) {
+        this.isAnswered = isAnswered;
+    }
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/entity/QnaBoard.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/entity/QnaBoard.java
@@ -1,0 +1,36 @@
+package com.kosa.springcoffee.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity(name = "sc_qna_board")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class QnaBoard extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long qnaBoardNo;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Column(length = 1500, nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member writer;
+
+    public void changeTitle(String title) {
+        this.title = title;
+    }
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
+}
+

--- a/back-end/src/main/java/com/kosa/springcoffee/entity/QnaReply.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/entity/QnaReply.java
@@ -1,0 +1,26 @@
+package com.kosa.springcoffee.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity(name = "sc_qna_reply")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class QnaReply extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long replyNo;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member replyer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private QnaBoard qnaBoard;
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/entity/QnaReply.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/entity/QnaReply.java
@@ -22,6 +22,7 @@ public class QnaReply extends BaseEntity {
     private Member replyer;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "qna_board_no")
     private QnaBoard qnaBoard;
 
     public void changeContent(String content) {

--- a/back-end/src/main/java/com/kosa/springcoffee/entity/QnaReply.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/entity/QnaReply.java
@@ -14,7 +14,7 @@ public class QnaReply extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long replyNo;
+    private Long qnaReplyNo;
 
     private String content;
 
@@ -23,4 +23,8 @@ public class QnaReply extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private QnaBoard qnaBoard;
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
 }

--- a/back-end/src/main/java/com/kosa/springcoffee/repository/BoardRepository.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/repository/BoardRepository.java
@@ -14,10 +14,10 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findByCategory(String category, Pageable pageable);
 
     @EntityGraph(attributePaths = "writer", type = EntityGraph.EntityGraphType.LOAD)
-    @Query("select b from sc_board b where b.boardNo = :boardNo")
+    @Query("select b from sc_notice_board b where b.boardNo = :boardNo")
     Optional<Board> getWithWriter(Long boardNo);
 
     @EntityGraph(attributePaths = {"writer"}, type = EntityGraph.EntityGraphType.LOAD)
-    @Query("select b from sc_board b where b.writer.email = :email")
+    @Query("select b from sc_notice_board b where b.writer.email = :email")
     List<Board> getList(String email);
 }

--- a/back-end/src/main/java/com/kosa/springcoffee/repository/QnaBoardRepository.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/repository/QnaBoardRepository.java
@@ -17,6 +17,10 @@ public interface QnaBoardRepository extends JpaRepository<QnaBoard, Long> {
 
     Page<QnaBoard> findByCategoryAndIsAnswered(String category, Boolean isAnswered, Pageable pageable);
 
+    Page<QnaBoard> findByTitleContaining(String keyword, Pageable pageable);
+
+    Page<QnaBoard> findByWriterEmailContaining(String email, Pageable pageable);
+
     @EntityGraph(attributePaths = "writer", type = EntityGraph.EntityGraphType.LOAD)
     @Query("select b from sc_qna_board b where b.qnaBoardNo = :qnaBoardNo")
     Optional<QnaBoard> getWithWriter(Long qnaBoardNo);

--- a/back-end/src/main/java/com/kosa/springcoffee/repository/QnaBoardRepository.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/repository/QnaBoardRepository.java
@@ -1,0 +1,20 @@
+package com.kosa.springcoffee.repository;
+
+import com.kosa.springcoffee.entity.QnaBoard;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QnaBoardRepository extends JpaRepository<QnaBoard, Long> {
+    @EntityGraph(attributePaths = "writer", type = EntityGraph.EntityGraphType.LOAD)
+    @Query("select b from sc_qna_board b where b.qnaBoardNo = :qnaBoardNo")
+    Optional<QnaBoard> getWithWriter(Long qnaBoardNo);
+
+    @EntityGraph(attributePaths = {"writer"}, type = EntityGraph.EntityGraphType.LOAD)
+    @Query("select b from sc_qna_board b where b.writer.email = :email")
+    List<QnaBoard> getList(String email);
+
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/repository/QnaBoardRepository.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/repository/QnaBoardRepository.java
@@ -15,6 +15,8 @@ public interface QnaBoardRepository extends JpaRepository<QnaBoard, Long> {
 
     Page<QnaBoard> findByIsAnswered(Boolean isAnswered, Pageable pageable);
 
+    Page<QnaBoard> findByCategoryAndIsAnswered(String category, Boolean isAnswered, Pageable pageable);
+
     @EntityGraph(attributePaths = "writer", type = EntityGraph.EntityGraphType.LOAD)
     @Query("select b from sc_qna_board b where b.qnaBoardNo = :qnaBoardNo")
     Optional<QnaBoard> getWithWriter(Long qnaBoardNo);

--- a/back-end/src/main/java/com/kosa/springcoffee/repository/QnaBoardRepository.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/repository/QnaBoardRepository.java
@@ -1,6 +1,8 @@
 package com.kosa.springcoffee.repository;
 
 import com.kosa.springcoffee.entity.QnaBoard;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +11,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface QnaBoardRepository extends JpaRepository<QnaBoard, Long> {
+    Page<QnaBoard> findByCategory(String category, Pageable pageable);
+
+    Page<QnaBoard> findByIsAnswered(Boolean isAnswered, Pageable pageable);
+
     @EntityGraph(attributePaths = "writer", type = EntityGraph.EntityGraphType.LOAD)
     @Query("select b from sc_qna_board b where b.qnaBoardNo = :qnaBoardNo")
     Optional<QnaBoard> getWithWriter(Long qnaBoardNo);

--- a/back-end/src/main/java/com/kosa/springcoffee/repository/QnaReplyRepository.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/repository/QnaReplyRepository.java
@@ -1,0 +1,13 @@
+package com.kosa.springcoffee.repository;
+
+import com.kosa.springcoffee.entity.QnaBoard;
+import com.kosa.springcoffee.entity.QnaReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface QnaReplyRepository extends JpaRepository<QnaReply, Long> {
+
+    Optional<QnaReply> findByQnaBoard(QnaBoard qnaBoard);
+
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/service/BoardService.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/BoardService.java
@@ -18,8 +18,11 @@ public interface BoardService {
     void modify(BoardDTO boardDTO);
 
     void remove(Long boardNo);
+
     List<BoardDTO> getAllWithWriter(String writerEmail);
+
     PageResultDTO<BoardDTO, Board> readAll(PageRequestDTO requestDTO); // 전체 조회
+
     PageResultDTO<BoardDTO, Board> getCategory(CategoryPageRequestDTO requestDTO); // 카테고리 조회
 
     default Board dtoToEntity(BoardDTO dto) {

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardService.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardService.java
@@ -1,0 +1,57 @@
+package com.kosa.springcoffee.service;
+
+import com.kosa.springcoffee.dto.*;
+import com.kosa.springcoffee.entity.Board;
+import com.kosa.springcoffee.entity.Member;
+import com.kosa.springcoffee.entity.QnaBoard;
+import com.sun.org.apache.xpath.internal.operations.Bool;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public interface QnaBoardService {
+
+    Long create(QnaBoardDTO dto); // 등록
+
+    PageResultDTO<QnaBoardDTO, QnaBoard> readAll(PageRequestDTO requestDTO); // 전체 조회
+
+    QnaBoardDTO get(Long qnaBoardNo); // 상세 조회
+
+    PageResultDTO<QnaBoardDTO, QnaBoard> getCategory(CategoryPageRequestDTO requestDTO); // 카테고리 조회
+
+    PageResultDTO<QnaBoardDTO, QnaBoard> getAnswered(AnsweredPageRequestDTO requestDTO); // 답변여부 조회
+
+    List<QnaBoardDTO> getAllWithWriter(String writerEmail); // 작성자 조회
+
+    void modify(QnaBoardDTO qnaBoardDTO);
+
+    void modifyIsAnswered(QnaBoardDTO qnaBoardDTO);
+
+    void remove(Long qnaBoardNo);
+
+
+    default QnaBoard dtoToEntity(QnaBoardDTO dto) {
+        QnaBoard entity = QnaBoard.builder()
+                .qnaBoardNo(dto.getQnaBoardNo())
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .writer(Member.builder().email(dto.getWriter()).build())
+                .category(dto.getCategory())
+                .build();
+        return entity;
+    }
+
+    default QnaBoardDTO entityToDto(QnaBoard entity) {
+        QnaBoardDTO dto = QnaBoardDTO.builder()
+                .qnaBoardNo(entity.getQnaBoardNo())
+                .title(entity.getTitle())
+                .content(entity.getContent())
+                .writer(entity.getWriter().getEmail())
+                .category(entity.getCategory())
+                .isAnswered(entity.getIsAnswered())
+                .modDate(entity.getModDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .regDate(entity.getRegDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .build();
+        return dto;
+    }
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardService.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardService.java
@@ -24,6 +24,10 @@ public interface QnaBoardService {
 
     List<QnaBoardDTO> getAllWithWriter(String writerEmail); // 작성자 조회
 
+    PageResultDTO<QnaBoardDTO, QnaBoard> searchKeyword(KeywordPageRequestDTO requestDTO); // 키워드 검색
+
+    PageResultDTO<QnaBoardDTO, QnaBoard> searchEmail(EmailPageRequestDTO requestDTO); // 작성자 검색
+
     void modify(QnaBoardDTO qnaBoardDTO);
 
     void modifyIsAnswered(Long qnaBoardNo, Boolean isAnswered);

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardService.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardService.java
@@ -6,6 +6,7 @@ import com.kosa.springcoffee.entity.QnaBoard;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public interface QnaBoardService {
 
@@ -47,6 +48,11 @@ public interface QnaBoardService {
                 .content(entity.getContent())
                 .writer(entity.getWriter().getEmail())
                 .category(entity.getCategory())
+                .replyList(entity.getQnaReplies().stream().map(qnaReply -> QnaReplyDTO.builder()
+                        .qnaReplyNo(qnaReply.getQnaReplyNo())
+                        .content(qnaReply.getContent())
+                        .replyer(qnaReply.getReplyer().getEmail())
+                        .qnaBoardNo(qnaReply.getQnaBoard().getQnaBoardNo()).build()).collect(Collectors.toList()))
                 .isAnswered(entity.getIsAnswered())
                 .modDate(entity.getModDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
                 .regDate(entity.getRegDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardService.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardService.java
@@ -25,10 +25,9 @@ public interface QnaBoardService {
 
     void modify(QnaBoardDTO qnaBoardDTO);
 
-    void modifyIsAnswered(QnaBoardDTO qnaBoardDTO);
+    void modifyIsAnswered(Long qnaBoardNo, Boolean isAnswered);
 
     void remove(Long qnaBoardNo);
-
 
     default QnaBoard dtoToEntity(QnaBoardDTO dto) {
         QnaBoard entity = QnaBoard.builder()

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardService.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardService.java
@@ -1,10 +1,8 @@
 package com.kosa.springcoffee.service;
 
 import com.kosa.springcoffee.dto.*;
-import com.kosa.springcoffee.entity.Board;
 import com.kosa.springcoffee.entity.Member;
 import com.kosa.springcoffee.entity.QnaBoard;
-import com.sun.org.apache.xpath.internal.operations.Bool;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -16,6 +14,8 @@ public interface QnaBoardService {
     PageResultDTO<QnaBoardDTO, QnaBoard> readAll(PageRequestDTO requestDTO); // 전체 조회
 
     QnaBoardDTO get(Long qnaBoardNo); // 상세 조회
+
+    PageResultDTO<QnaBoardDTO, QnaBoard> getCategoryAndAnswered(QnaCategoryAnsweredPageRequestDTO requestDTO);
 
     PageResultDTO<QnaBoardDTO, QnaBoard> getCategory(CategoryPageRequestDTO requestDTO); // 카테고리 조회
 

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardServiceImpl.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardServiceImpl.java
@@ -107,13 +107,12 @@ public class QnaBoardServiceImpl implements QnaBoardService{
     }
 
     @Override
-    public void modifyIsAnswered(QnaBoardDTO qnaBoardDTO) {
-        Long qnaBoardNo = qnaBoardDTO.getQnaBoardNo();
+    public void modifyIsAnswered(Long qnaBoardNo, Boolean isAnswered) {
         Optional<QnaBoard> result = qnaBoardRepository.findById(qnaBoardNo);
 
         if(result.isPresent()){
             QnaBoard qnaBoard = result.get();
-            qnaBoard.changeIsAnswered(!qnaBoardDTO.getIsAnswered());
+            qnaBoard.changeIsAnswered(isAnswered);
             qnaBoardRepository.save(qnaBoard);
         }
     }

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardServiceImpl.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardServiceImpl.java
@@ -94,6 +94,28 @@ public class QnaBoardServiceImpl implements QnaBoardService{
     }
 
     @Override
+    public PageResultDTO<QnaBoardDTO, QnaBoard> searchKeyword(KeywordPageRequestDTO requestDTO) {
+        Pageable pageable = requestDTO.getPageable(Sort.by("qnaBoardNo").descending());
+
+        Page<QnaBoard> result = qnaBoardRepository.findByTitleContaining(requestDTO.getKeyword(), pageable);
+
+        Function<QnaBoard, QnaBoardDTO> fn = (entity -> entityToDto(entity));
+
+        return new PageResultDTO<>(result, fn);
+    }
+
+    @Override
+    public PageResultDTO<QnaBoardDTO, QnaBoard> searchEmail(EmailPageRequestDTO requestDTO) {
+        Pageable pageable = requestDTO.getPageable(Sort.by("qnaBoardNo").descending());
+
+        Page<QnaBoard> result = qnaBoardRepository.findByWriterEmailContaining(requestDTO.getEmail(), pageable);
+
+        Function<QnaBoard, QnaBoardDTO> fn = (entity -> entityToDto(entity));
+
+        return new PageResultDTO<>(result, fn);
+    }
+
+    @Override
     public void modify(QnaBoardDTO qnaBoardDTO) {
         Long qnaBoardNo = qnaBoardDTO.getQnaBoardNo();
         Optional<QnaBoard> result = qnaBoardRepository.findById(qnaBoardNo);

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardServiceImpl.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardServiceImpl.java
@@ -1,0 +1,117 @@
+package com.kosa.springcoffee.service;
+
+import com.kosa.springcoffee.dto.*;
+import com.kosa.springcoffee.entity.Board;
+import com.kosa.springcoffee.entity.QnaBoard;
+import com.kosa.springcoffee.repository.QnaBoardRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class QnaBoardServiceImpl implements QnaBoardService{
+
+    private final QnaBoardRepository qnaBoardRepository;
+
+    @Override
+    public Long create(QnaBoardDTO dto) {
+        QnaBoard entity = dtoToEntity(dto);
+        qnaBoardRepository.save(entity);
+
+        return entity.getQnaBoardNo();
+    }
+
+    @Override
+    public PageResultDTO<QnaBoardDTO, QnaBoard> readAll(PageRequestDTO requestDTO) {
+        Pageable pageable = requestDTO.getPageable(Sort.by("qnaBoardNo").descending());
+
+        Page<QnaBoard> result = qnaBoardRepository.findAll(pageable);
+
+        Function<QnaBoard, QnaBoardDTO> fn = (entity -> entityToDto(entity));
+
+        return new PageResultDTO<>(result, fn);
+    }
+
+    @Override
+    public QnaBoardDTO get(Long qnaBoardNo) {
+        Optional<QnaBoard> result = qnaBoardRepository.getWithWriter(qnaBoardNo);
+
+        if(result.isPresent()){
+            return entityToDto(result.get());
+        }
+
+        return null;
+    }
+
+    @Override
+    public PageResultDTO<QnaBoardDTO, QnaBoard> getCategory(CategoryPageRequestDTO requestDTO) {
+        Pageable pageable = requestDTO.getPageable(Sort.by("qnaBoardNo").descending());
+
+        System.out.println(requestDTO);
+        Page<QnaBoard> result = qnaBoardRepository.findByCategory(requestDTO.getCategory(), pageable);
+
+        Function<QnaBoard, QnaBoardDTO> fn = (entity -> entityToDto(entity));
+
+        return new PageResultDTO<>(result, fn);
+    }
+
+    @Override
+    public PageResultDTO<QnaBoardDTO, QnaBoard> getAnswered(AnsweredPageRequestDTO requestDTO) {
+        Pageable pageable = requestDTO.getPageable(Sort.by("qnaBoardNo").descending());
+
+        System.out.println(requestDTO);
+        Page<QnaBoard> result = qnaBoardRepository.findByIsAnswered(requestDTO.getIsAnswered(), pageable);
+
+        Function<QnaBoard, QnaBoardDTO> fn = (entity -> entityToDto(entity));
+
+        return new PageResultDTO<>(result, fn);
+    }
+
+    @Override
+    public List<QnaBoardDTO> getAllWithWriter(String writerEmail) {
+        List<QnaBoard> qnaBoardList = qnaBoardRepository.getList(writerEmail);
+
+        return qnaBoardList.stream().map(qnaBoard -> entityToDto(qnaBoard))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void modify(QnaBoardDTO qnaBoardDTO) {
+        Long qnaBoardNo = qnaBoardDTO.getQnaBoardNo();
+        Optional<QnaBoard> result = qnaBoardRepository.findById(qnaBoardNo);
+
+        if(result.isPresent()){
+            QnaBoard qnaBoard = result.get();
+            qnaBoard.changeTitle(qnaBoardDTO.getTitle());
+            qnaBoard.changeContent(qnaBoardDTO.getContent());
+            qnaBoardRepository.save(qnaBoard);
+        }
+    }
+
+    @Override
+    public void modifyIsAnswered(QnaBoardDTO qnaBoardDTO) {
+        Long qnaBoardNo = qnaBoardDTO.getQnaBoardNo();
+        Optional<QnaBoard> result = qnaBoardRepository.findById(qnaBoardNo);
+
+        if(result.isPresent()){
+            QnaBoard qnaBoard = result.get();
+            qnaBoard.changeIsAnswered(!qnaBoardDTO.getIsAnswered());
+            qnaBoardRepository.save(qnaBoard);
+        }
+    }
+
+    @Override
+    public void remove(Long qnaBoardNo) {
+        qnaBoardRepository.deleteById(qnaBoardNo);
+    }
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardServiceImpl.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaBoardServiceImpl.java
@@ -1,7 +1,6 @@
 package com.kosa.springcoffee.service;
 
 import com.kosa.springcoffee.dto.*;
-import com.kosa.springcoffee.entity.Board;
 import com.kosa.springcoffee.entity.QnaBoard;
 import com.kosa.springcoffee.repository.QnaBoardRepository;
 import lombok.RequiredArgsConstructor;
@@ -57,7 +56,6 @@ public class QnaBoardServiceImpl implements QnaBoardService{
     public PageResultDTO<QnaBoardDTO, QnaBoard> getCategory(CategoryPageRequestDTO requestDTO) {
         Pageable pageable = requestDTO.getPageable(Sort.by("qnaBoardNo").descending());
 
-        System.out.println(requestDTO);
         Page<QnaBoard> result = qnaBoardRepository.findByCategory(requestDTO.getCategory(), pageable);
 
         Function<QnaBoard, QnaBoardDTO> fn = (entity -> entityToDto(entity));
@@ -69,8 +67,18 @@ public class QnaBoardServiceImpl implements QnaBoardService{
     public PageResultDTO<QnaBoardDTO, QnaBoard> getAnswered(AnsweredPageRequestDTO requestDTO) {
         Pageable pageable = requestDTO.getPageable(Sort.by("qnaBoardNo").descending());
 
-        System.out.println(requestDTO);
         Page<QnaBoard> result = qnaBoardRepository.findByIsAnswered(requestDTO.getIsAnswered(), pageable);
+
+        Function<QnaBoard, QnaBoardDTO> fn = (entity -> entityToDto(entity));
+
+        return new PageResultDTO<>(result, fn);
+    }
+
+    @Override
+    public PageResultDTO<QnaBoardDTO, QnaBoard> getCategoryAndAnswered(QnaCategoryAnsweredPageRequestDTO requestDTO) {
+        Pageable pageable = requestDTO.getPageable(Sort.by("qnaBoardNo").descending());
+
+        Page<QnaBoard> result = qnaBoardRepository.findByCategoryAndIsAnswered(requestDTO.getCategory(), requestDTO.getIsAnswered(), pageable);
 
         Function<QnaBoard, QnaBoardDTO> fn = (entity -> entityToDto(entity));
 

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaReplyService.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaReplyService.java
@@ -1,0 +1,15 @@
+package com.kosa.springcoffee.service;
+
+import com.kosa.springcoffee.dto.QnaReplyDTO;
+
+
+public interface QnaReplyService {
+
+    Long create(QnaReplyDTO dto); // 생성
+
+    QnaReplyDTO get(Long qnaBoardNo); // 상세 조회
+
+    void modify(QnaReplyDTO dto); // 수정
+
+    void remove(Long qnaReplyNo); // 삭제
+}

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaReplyServiceImpl.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaReplyServiceImpl.java
@@ -36,8 +36,8 @@ public class QnaReplyServiceImpl implements QnaReplyService{
     }
 
     @Override
-    public QnaReplyDTO get(Long qnaBoardNo) {
-        Optional<QnaReply> result = qnaReplyRepository.findByQnaBoard(QnaBoard.builder().qnaBoardNo(qnaBoardNo).build());
+    public QnaReplyDTO get(Long qnaReplyNo) {
+        Optional<QnaReply> result = qnaReplyRepository.findById(qnaReplyNo);
 
         if (result.isPresent()) {
             QnaReply entity = result.get();

--- a/back-end/src/main/java/com/kosa/springcoffee/service/QnaReplyServiceImpl.java
+++ b/back-end/src/main/java/com/kosa/springcoffee/service/QnaReplyServiceImpl.java
@@ -1,0 +1,74 @@
+package com.kosa.springcoffee.service;
+
+import com.kosa.springcoffee.dto.QnaReplyDTO;
+import com.kosa.springcoffee.entity.Member;
+import com.kosa.springcoffee.entity.QnaBoard;
+import com.kosa.springcoffee.entity.QnaReply;
+import com.kosa.springcoffee.repository.QnaReplyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class QnaReplyServiceImpl implements QnaReplyService{
+
+    private final QnaReplyRepository qnaReplyRepository;
+
+    private final QnaBoardService qnaBoardService;
+
+    @Override
+    public Long create(QnaReplyDTO dto) {
+
+        QnaReply entity = QnaReply.builder()
+                        .qnaReplyNo(dto.getQnaReplyNo())
+                        .content(dto.getContent())
+                        .replyer(Member.builder().email(dto.getReplyer()).build())
+                        .qnaBoard(QnaBoard.builder().qnaBoardNo(dto.getQnaBoardNo()).build()).build();
+
+        qnaReplyRepository.save(entity);
+        qnaBoardService.modifyIsAnswered(dto.getQnaBoardNo(), true);
+
+        return entity.getQnaReplyNo();
+    }
+
+    @Override
+    public QnaReplyDTO get(Long qnaBoardNo) {
+        Optional<QnaReply> result = qnaReplyRepository.findByQnaBoard(QnaBoard.builder().qnaBoardNo(qnaBoardNo).build());
+
+        if (result.isPresent()) {
+            QnaReply entity = result.get();
+
+            QnaReplyDTO qnaReplyDTO = QnaReplyDTO.builder()
+                    .qnaReplyNo(entity.getQnaReplyNo())
+                    .content(entity.getContent())
+                    .replyer(entity.getReplyer().getEmail())
+                    .qnaBoardNo(entity.getQnaBoard().getQnaBoardNo()).build();
+            return qnaReplyDTO;
+        }
+
+        return null;
+    }
+
+    @Override
+    public void modify(QnaReplyDTO dto) {
+        Long qnaReplyNo = dto.getQnaReplyNo();
+        Optional<QnaReply> result = qnaReplyRepository.findById(qnaReplyNo);
+
+        if (result.isPresent()){
+            QnaReply qnaReply = result.get();
+            qnaReply.changeContent(dto.getContent());
+            qnaReplyRepository.save(qnaReply);
+        }
+    }
+
+    @Override
+    public void remove(Long qnaReplyNo) {
+        Long qnaBoardNo = qnaReplyRepository.findById(qnaReplyNo).get().getQnaBoard().getQnaBoardNo();
+        qnaReplyRepository.deleteById(qnaReplyNo);
+        qnaBoardService.modifyIsAnswered(qnaBoardNo, false);
+    }
+}

--- a/back-end/src/test/java/com/kosa/springcoffee/repository/BoardRepositoryTest.java
+++ b/back-end/src/test/java/com/kosa/springcoffee/repository/BoardRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.kosa.springcoffee.repository;
+
+import com.kosa.springcoffee.entity.Board;
+import com.kosa.springcoffee.entity.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+        import java.util.stream.IntStream;
+
+@SpringBootTest
+public class BoardRepositoryTest {
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    public void insertDummies() {
+        IntStream.rangeClosed(1,100).forEach(i -> {
+            Optional<Member> result = memberRepository.findByEmail("user"+i+"@springCoffee.com" , false);
+            Member member = result.get();
+            Board noticeBoard = Board.builder()
+                    .title("Title"+ i)
+                    .content("Content" + i)
+                    .writer(member)
+                    .category("notice")
+                    .build();
+            System.out.println(boardRepository.save(noticeBoard));
+        });
+        IntStream.rangeClosed(101,200).forEach(i -> {
+            Optional<Member> result = memberRepository.findByEmail("user"+(i-100)+"@springCoffee.com" , false);
+            Member member = result.get();
+            Board noticeBoard = Board.builder()
+                    .title("Title"+ i)
+                    .content("Content" + i)
+                    .writer(member)
+                    .category("qna")
+                    .build();
+            System.out.println(boardRepository.save(noticeBoard));
+        });
+        IntStream.rangeClosed(201,300).forEach(i -> {
+            Optional<Member> result = memberRepository.findByEmail("user"+(i-200)+"@springCoffee.com" , false);
+            Member member = result.get();
+            Board noticeBoard = Board.builder()
+                    .title("Title"+ i)
+                    .content("Content" + i)
+                    .writer(member)
+                    .category("coffee")
+                    .build();
+            System.out.println(boardRepository.save(noticeBoard));
+        });
+    }
+
+//    @Test
+//    public void updateTest() {
+//        Optional<Board> result = boardRepository.findById(300L);
+//
+//        if (result.isPresent()) {
+//            Board noticeBoard = result.get();
+//
+//            noticeBoard.changeTitle("Changed Title");
+//            noticeBoard.changeContent("Changed Content");
+//
+//            boardRepository.save(noticeBoard);
+//        }
+//    }
+}
+

--- a/back-end/src/test/java/com/kosa/springcoffee/repository/QnaBoardRepositoryTest.java
+++ b/back-end/src/test/java/com/kosa/springcoffee/repository/QnaBoardRepositoryTest.java
@@ -1,0 +1,35 @@
+package com.kosa.springcoffee.repository;
+
+import com.kosa.springcoffee.entity.Member;
+import com.kosa.springcoffee.entity.QnaBoard;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+@SpringBootTest
+//@RunWith(SpringJUnit4ClassRunner.class)
+public class QnaBoardRepositoryTest {
+
+    @Autowired
+    private QnaBoardRepository qnABoardRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    public void insertDummies() {
+        IntStream.rangeClosed(1,100).forEach(i -> {
+            Optional<Member> result = memberRepository.findByEmail("user"+i+"@springCoffee.com" , false);
+            Member member = result.get();
+            QnaBoard qnaBoard = QnaBoard.builder()
+                    .title("qna Title"+ i)
+                    .content("qna Content" + i)
+                    .writer(member)
+                    .build();
+            System.out.println(qnABoardRepository.save(qnaBoard));
+        });
+    }
+}

--- a/back-end/src/test/java/com/kosa/springcoffee/repository/QnaBoardRepositoryTest.java
+++ b/back-end/src/test/java/com/kosa/springcoffee/repository/QnaBoardRepositoryTest.java
@@ -21,13 +21,50 @@ public class QnaBoardRepositoryTest {
 
     @Test
     public void insertDummies() {
-        IntStream.rangeClosed(1,100).forEach(i -> {
+        IntStream.rangeClosed(1,25).forEach(i -> {
             Optional<Member> result = memberRepository.findByEmail("user"+i+"@springCoffee.com" , false);
             Member member = result.get();
             QnaBoard qnaBoard = QnaBoard.builder()
                     .title("qna Title"+ i)
                     .content("qna Content" + i)
                     .writer(member)
+                    .category("상품문의")
+                    .build();
+            System.out.println(qnABoardRepository.save(qnaBoard));
+        });
+
+        IntStream.rangeClosed(26,50).forEach(i -> {
+            Optional<Member> result = memberRepository.findByEmail("user"+i+"@springCoffee.com" , false);
+            Member member = result.get();
+            QnaBoard qnaBoard = QnaBoard.builder()
+                    .title("qna Title"+ i)
+                    .content("qna Content" + i)
+                    .writer(member)
+                    .category("배송문의")
+                    .build();
+            System.out.println(qnABoardRepository.save(qnaBoard));
+        });
+
+        IntStream.rangeClosed(51,75).forEach(i -> {
+            Optional<Member> result = memberRepository.findByEmail("user"+i+"@springCoffee.com" , false);
+            Member member = result.get();
+            QnaBoard qnaBoard = QnaBoard.builder()
+                    .title("qna Title"+ i)
+                    .content("qna Content" + i)
+                    .writer(member)
+                    .category("교환 및 반품문의")
+                    .build();
+            System.out.println(qnABoardRepository.save(qnaBoard));
+        });
+
+        IntStream.rangeClosed(76,100).forEach(i -> {
+            Optional<Member> result = memberRepository.findByEmail("user"+i+"@springCoffee.com" , false);
+            Member member = result.get();
+            QnaBoard qnaBoard = QnaBoard.builder()
+                    .title("qna Title"+ i)
+                    .content("qna Content" + i)
+                    .writer(member)
+                    .category("기타")
                     .build();
             System.out.println(qnABoardRepository.save(qnaBoard));
         });


### PR DESCRIPTION
## qna 게시판 분리 -> 기존 게시판(board) 테이블명 sc_notice_board로 수정

## QnaBoard isAnswered default false로 설정되도록 builder 구현

## qna 게시판 CRUD 구현
1. 조회
- 전체 조회
- 상세 조회 : 답변 리스트 함께 조회가능하도록 수정함.
- 카테고리 조회
- 답변 여부 조회
- 카테고리 별 답변 여부 조회
- 작성자 조회
2. 등록
- 문의 등록
3. 수정
- 제목, 내용 수정
- 답변 여부 수정
4. 삭제
- qnaReply도 자동 삭제되도록 매핑

## qna 댓글 CRUD 구현
1. 조회
- qnaReplyNo로 조회
2. 등록
- qnaBoardNo로 등록
- qnaBoard isAnswered -> true로 변경되도록 구현
3. 수정
- 내용 수정
4. 삭제
- qnaBoard isAnswered -> false 로 변경되도록 구현

## 제목 및 작성자 검색기능 추가